### PR TITLE
style(ui): refine chat panel visual continuityPr/chat UI polish

### DIFF
--- a/apps/frontend/src/app/App.css
+++ b/apps/frontend/src/app/App.css
@@ -241,6 +241,14 @@ body {
   gap: 16px;
 }
 
+/* When context-tags immediately follow panel-header, merge them visually */
+.panel-header + .context-tags {
+  background: var(--panel-muted);
+  border-bottom: 1px solid var(--border);
+  margin-top: -1px;
+  padding: 6px 14px 8px;
+}
+
 .header-controls {
   display: flex;
   gap: 8px;
@@ -638,11 +646,15 @@ body {
 .side-panel .chat-messages {
   flex: 1;
   padding: 12px;
+  padding-bottom: 18px;
   overflow-y: auto;
   display: flex;
   flex-direction: column;
   gap: 10px;
   min-height: 0;
+  position: relative;
+  mask-image: linear-gradient(to bottom, black calc(100% - 24px), transparent 100%);
+  -webkit-mask-image: linear-gradient(to bottom, black calc(100% - 24px), transparent 100%);
 }
 
 .chat-msg {
@@ -667,12 +679,14 @@ body {
 
 .chat-controls {
   padding: 10px 12px 12px;
-  border-top: 1px solid var(--border);
+  border-top: none;
+  box-shadow: 0 -6px 12px -4px rgba(120, 98, 83, 0.06);
   display: flex;
   flex-direction: column;
   gap: 8px;
   position: relative;
   overflow: visible;
+  background: linear-gradient(to bottom, rgba(255, 253, 249, 0.6), rgba(255, 253, 249, 1) 8px);
 }
 
 .chat-control-row {

--- a/apps/frontend/src/app/App.css
+++ b/apps/frontend/src/app/App.css
@@ -241,12 +241,16 @@ body {
   gap: 16px;
 }
 
-/* When context-tags immediately follow panel-header, merge them visually */
+/* When context-tags follow panel-header, merge into one unified header block */
+.panel-header:has(+ .context-tags) {
+  border-bottom: none;
+  padding-bottom: 4px;
+}
+
 .panel-header + .context-tags {
   background: var(--panel-muted);
-  border-bottom: 1px solid var(--border);
-  margin-top: -1px;
-  padding: 6px 14px 8px;
+  border-bottom: 2px solid var(--border);
+  padding: 3px 14px 8px;
 }
 
 .header-controls {

--- a/apps/frontend/src/app/App.css
+++ b/apps/frontend/src/app/App.css
@@ -249,8 +249,22 @@ body {
 
 .panel-header + .context-tags {
   background: var(--panel-muted);
-  border-bottom: 2px solid var(--border);
-  padding: 3px 14px 8px;
+  border-bottom: none;
+  padding: 2px 14px 10px;
+  position: relative;
+  z-index: 1;
+}
+
+.panel-header + .context-tags::after {
+  content: '';
+  position: absolute;
+  bottom: -20px;
+  left: 0;
+  right: 0;
+  height: 20px;
+  background: linear-gradient(to bottom, rgba(120, 98, 83, 0.01), transparent);
+  pointer-events: none;
+  z-index: 1;
 }
 
 .header-controls {
@@ -657,8 +671,8 @@ body {
   gap: 10px;
   min-height: 0;
   position: relative;
-  mask-image: linear-gradient(to bottom, black calc(100% - 24px), transparent 100%);
-  -webkit-mask-image: linear-gradient(to bottom, black calc(100% - 24px), transparent 100%);
+  mask-image: linear-gradient(to bottom, transparent 0%, black 24px, black calc(100% - 24px), transparent 100%);
+  -webkit-mask-image: linear-gradient(to bottom, transparent 0%, black 24px, black calc(100% - 24px), transparent 100%);
 }
 
 .chat-msg {

--- a/apps/frontend/src/app/App.css
+++ b/apps/frontend/src/app/App.css
@@ -663,8 +663,7 @@ body {
 .chat-panel .chat-messages,
 .side-panel .chat-messages {
   flex: 1;
-  padding: 12px;
-  padding-bottom: 18px;
+  padding: 24px 12px;
   overflow-y: auto;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary

  This PR makes a few visual refinements to the chat panel UI.

  ### Changes included
  - visually merge the panel header and context tags into a more unified block
  - add a soft fade effect to the chat message scroll area
  - soften the top edge of the chat controls with a shadow and subtle gradient

  ## Motivation

  These changes aim to improve visual continuity in the chat panel and make the layout feel less segmented, especially around the header and input area.

  ## Testing

  - [x] `npm run build`
  - [x] visually verified the updated chat panel styles

  ## Notes

  This PR is intentionally limited to UI polish in `App.css` only.

## Screenshot
  <p align="center">
    <img width="320" alt="Conversation UI" src="https://github.com/user-attachments/assets/90fc7aec-6905-4354-a96c-4e8bca299ed7" />
  </p>

